### PR TITLE
Remove spaces from test results

### DIFF
--- a/homework03/src/Golf.hs
+++ b/homework03/src/Golf.hs
@@ -14,13 +14,13 @@ module Golf where
 -- |
 --
 -- >>> skips "ABCD"
--- ["ABCD", "BD", "C", "D"]
+-- ["ABCD","BD","C","D"]
 -- >>> skips "hello!"
--- ["hello!", "el!", "l!", "l", "o", "!"]
+-- ["hello!","el!","l!","l","o","!"]
 -- >>> skips [1]
 -- [[1]]
 -- >>> skips [True, False]
--- [[True,False], [False]]
+-- [[True,False],[False]]
 -- >>> skips []
 -- []
 


### PR DESCRIPTION
Homework03 test fails because of these spaces: 

`["ABCD", "BD", "C", "D"]`

It should be: 

`["ABCD","BD","C","D"]`
