### PR TITLE
Delete wrong example Homework 08

### DIFF
--- a/homework08/src/Employee.hs
+++ b/homework08/src/Employee.hs
@@ -17,22 +17,7 @@ data Employee = Emp { empName :: Name, empFun :: Fun }
 testCompany :: Tree Employee
 testCompany
   = Node (Emp "Stan" 9)
-    [ Node (Emp "Bob" 2)
-      [ Node (Emp "Joe" 5)
-        [ Node (Emp "John" 1) []
-        , Node (Emp "Sue" 5) []
-        ]
-      , Node (Emp "Fred" 3) []
-      ]
-    , Node (Emp "Sarah" 17)
-      [ Node (Emp "Sam" 4) []
-      ]
-    ]
-
-testCompany2 :: Tree Employee
-testCompany2
-  = Node (Emp "Stan" 9)
-    [ Node (Emp "Bob" 3) -- (8, 8)
+    [ Node (Emp "Bob" 2) -- (8, 8)
       [ Node (Emp "Joe" 5) -- (5, 6)
         [ Node (Emp "John" 1) [] -- (1, 0)
         , Node (Emp "Sue" 5) [] -- (5, 0)


### PR DESCRIPTION
Only one `testCompany` is required for the Homework. `testCompany2` has Bob's fun score changed to 3, but has the comments tips correct for `testCompany`, which is misleading while solving Exercise 4.