### PR TITLE
Update Cabal file

### DIFF
--- a/cis194-templates.cabal
+++ b/cis194-templates.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 67361e1b2b8acd8cf9a0b186b0dd84a66c09705b05b46afa7585b4f3b4091465
+-- hash: f5880f8dc093907c216893df95c59cf8563dcf741ea1f728bc96693dbe8df55c
 
 name:           cis194-templates
 version:        0.1.0.0
@@ -12,7 +12,7 @@ description:    Please see the README on GitHub at <https://github.com/stackbuil
 homepage:       https://github.com/stackbuilders/cis194-templates#readme
 bug-reports:    https://github.com/stackbuilders/cis194-templates/issues
 author:         Stack Builders
-maintainer:     info@stackbuilders.com
+maintainer:     haskellers@stackbuilders.com
 copyright:      2016-2019 Stack Builders Inc.
 license:        MIT
 license-file:   LICENSE

--- a/cis194-templates.cabal
+++ b/cis194-templates.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 0e08e1247e98a7321ee9541698b60994b33b165e2a8892ce939f461c0bc9e667
+-- hash: 67361e1b2b8acd8cf9a0b186b0dd84a66c09705b05b46afa7585b4f3b4091465
 
 name:           cis194-templates
 version:        0.1.0.0
@@ -12,7 +12,7 @@ description:    Please see the README on GitHub at <https://github.com/stackbuil
 homepage:       https://github.com/stackbuilders/cis194-templates#readme
 bug-reports:    https://github.com/stackbuilders/cis194-templates/issues
 author:         Stack Builders
-maintainer:     haskell@stackbuilders.com
+maintainer:     info@stackbuilders.com
 copyright:      2016-2019 Stack Builders Inc.
 license:        MIT
 license-file:   LICENSE

--- a/package.yaml
+++ b/package.yaml
@@ -4,7 +4,7 @@ github:              "stackbuilders/cis194-templates"
 license:             MIT
 license-file:        LICENSE
 author:              "Stack Builders"
-maintainer:          "info@stackbuilders.com"
+maintainer:          "haskellers@stackbuilders.com"
 copyright:           "2016-2019 Stack Builders Inc."
 
 extra-source-files:
@@ -66,4 +66,3 @@ tests:
     dependencies:
       - cis194-templates
       - hspec
-


### PR DESCRIPTION
It looks like the Cabal file was out of date. Was the change from haskell@stackbuilders.com to info@stackbuilders.com intentional?