### PR TITLE
Add args to examples test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+homework-03-examples:
+	stack build --file-watch --test :doctest --test-arguments src/Homework03/Golf.hs

--- a/test/doctest/Main.hs
+++ b/test/doctest/Main.hs
@@ -1,6 +1,12 @@
 module Main where
 
+-- base
+import System.Environment (getArgs)
+
+-- doctest
 import Test.DocTest
 
 main :: IO ()
-main = doctest ["src"]
+main = do
+  args <- getArgs
+  doctest (if null args then ["src"] else args)


### PR DESCRIPTION
This could be fancier, but for now I just want a way to quickly run the examples without having to do anything else. In this case, it's just doing `make homework-03-examples`.